### PR TITLE
Revert shared library changes

### DIFF
--- a/integration/oqs_openssh/README.md
+++ b/integration/oqs_openssh/README.md
@@ -34,6 +34,10 @@ Then run:
 	cd testing/integration/oqs_openssh
 	./run.sh
 
-A file named 'logs' is created under the `tmp` direcory showing detailed output not shown in stdout or stderr for debugging purposes.  
+A file named 'logs' is created under the `tmp` directory showing detailed output not shown in stdout or stderr for debugging purposes.
+
+Alternatively, to log the run.sh output while following live, try:
+
+    ./run.sh | tee `date "+%Y%m%d-%Hh%Mm%Ss-openssh.log.txt"`
 
 OQS developers should record their test results on the OQS [test coverage wiki page](https://github.com/open-quantum-safe/testing/wiki/Configurations-test-coverage).

--- a/integration/oqs_openssh/run.sh
+++ b/integration/oqs_openssh/run.sh
@@ -118,7 +118,7 @@ if [ $? -eq 1 ] ; then
     if [ $? -eq 1 ] ; then
       CC_OVERRIDE=`which gcc-5`
       if [ $? -eq 1 ] ; then
-        A=`gcc --version | grep gcc| cut -b 11`
+        A=`gcc -dumpversion | cut -b 1`
         if [ $A -ge 5 ];then
           CC_OVERRIDE=`which gcc`
           echo "Found gcc >= 5 to build liboqs-nist" 2>&1 | tee -a $LOGS

--- a/integration/oqs_openssl/README.md
+++ b/integration/oqs_openssl/README.md
@@ -25,6 +25,10 @@ Then run:
 	cd testing/integration/oqs_openssl
 	./run.sh 2>/dev/null
 
-A file named 'logs' is created under the `tmp` direcory showing detailed output not shown in stdout or stderr for debugging purposes.  
+A file named 'logs' is created under the `tmp` directory showing detailed output not shown in stdout or stderr for debugging purposes.
+
+Alternatively, to log the run.sh output while following live, try:
+
+    ./run.sh | tee `date "+%Y%m%d-%Hh%Mm%Ss-openssl.log.txt"`
 
 OQS developers should record their test results on the OQS [test coverage wiki page](https://github.com/open-quantum-safe/testing/wiki/Configurations-test-coverage).

--- a/integration/oqs_openssl/run.sh
+++ b/integration/oqs_openssl/run.sh
@@ -13,18 +13,26 @@ OPENSSL111_SIGS_NIST="rsa"
 
 CC_OVERRIDE=`which clang`
 if [ $? -eq 1 ] ; then
-    CC_OVERRIDE=`which gcc-7`
+  CC_OVERRIDE=`which gcc-7`
+  if [ $? -eq 1 ] ; then
+    CC_OVERRIDE=`which gcc-6`
     if [ $? -eq 1 ] ; then
-        CC_OVERRIDE=`which gcc-6`
-        if [ $? -eq 1 ] ; then
-            CC_OVERRIDE=`which gcc-5`
-            if [ $? -eq 1 ] ; then
-                echo "Need gcc >= 5 to build liboqs-nist"
-                exit 1
-            fi
+      CC_OVERRIDE=`which gcc-5`
+      if [ $? -eq 1 ] ; then
+        A=`gcc -dumpversion | cut -b 1`
+        if [ $A -ge 5 ];then
+          CC_OVERRIDE=`which gcc`
+          echo "Found gcc >= 5 to build liboqs-nist" 2>&1 | tee -a $LOGS
+        else
+          echo "Need gcc >= 5 to build liboqs-nist"  2>&1 | tee -a $LOGS
+          exit 1
         fi
+      fi
     fi
+  fi
 fi
+
+
 
 set -e
 


### PR DESCRIPTION
@smashra, commits dd417002a89b2c98190a541494551fd0a9bfc119 and 72f7cfa63f6bc300452ecd6ac96715384b490800 broke the integration tests for me on macOS 10.14 and various Ubuntus.  I tried for several hours to get them working, but to no avail.  I've reverted to prior versions which do work.  

At this point in time, the integration tests reflect an automated version of what the README.md's instructions are -- and nothing more.  The README.md instructions don't build shared libraries, and so I'm fine with the integration tests not doing it.

If you're able to get them working again and they work reliably on all our target platforms, then we can re-add them.