### PR TITLE
Enable basic Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,73 @@
+language: c
+cache: ccache
+
+before_install:
+  - pwd
+  - sudo mkdir -p -m 0755 /var/empty
+
+addons:
+  apt:
+    update: true
+    packages:
+    - autoconf
+    - automake
+    - libtool
+    - libssl-dev
+    - make
+    - unzip
+    - xsltproc
+
+matrix:
+  include:
+  - os: linux
+    dist: xenial
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - gcc
+  - os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        sources:
+        - gcc
+  - os: osx
+    compiler: clang
+    install:
+    - export PATH="/usr/local/opt/ccache/libexec:$PATH"
+    addons:
+      homebrew:
+        packages:
+        - doxygen
+        - ccache
+        update: false
+    env:
+      - ARCH=x64
+      - CC_OVERRIDE=clang
+
+script:
+  - pwd
+  - echo "Using GGC  version:"
+  - gcc --version
+  - echo Running openssh-portable integration tests...
+  - cd integration/oqs_openssh
+  - OPENSSH_LOG_PATH=`date "+%Y%m%d-%Hh%Mm%Ss-openssh.log.txt"`
+  - time ./run.sh | tee $OPENSSH_LOG_PATH
+  - echo
+  - echo ls *log.txt
+  - echo
+  - echo "Last 100 lines of the SSH build logs:"
+  - tail -n 100 $OPENSSH_LOG_PATH
+  - cd ..
+  - echo
+  - echo Running openssl integration tests...
+  - cd oqs_openssl
+  - OPENSSL_LOG_PATH=`date "+%Y%m%d-%Hh%Mm%Ss-openssl.log.txt"`
+  - time ./run.sh | tee $OPENSSL_LOG_PATH
+  - echo
+  - echo ls *log.txt
+  - echo
+  - echo "Last 100 lines of the SSL build logs:"
+  - tail -n 100 $OPENSSL_LOG_PATH

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ OQS Integration Testing
 
 The **Open Quantum Safe (OQS) project** has the goal of developing and prototyping quantum-resistant cryptography.  [liboqs](https://github.com/open-quantum-safe/liboqs) is an open source C library for post-quantum cryptographic algorithms.  The OQS project has developed forks of [OpenSSH](https://github.com/open-quantum-safe/openssh-portable) and [OpenSSL](https://github.com/open-quantum-safe/openssl) that integrate quantum-resistant algorithms into the SSH and TLS protocols.
 
-This repository contains scripts for testing the integration of liboqs into OpenSSH and OpenSSL.  
+This repository contains scripts for testing the integration of liboqs into OpenSSH and OpenSSL.
 
 Please check the README.md files under the integration/oqs-openssh and integration/oqs-openssl directories for details on how to run the respective tests.
 
 OQS developers should record their test results on the OQS [test coverage wiki page](https://github.com/open-quantum-safe/testing/wiki/Configurations-test-coverage).
+
+Integration testing has been added for [Travis CI/build system](https://travis-ci.org/open-quantum-safe/testing).
 
 Dependencies
 ------------
@@ -18,7 +20,7 @@ You must install the relevant dependices before proceeding with running any test
 
 	sudo apt update
 	sudo apt install build-essential autotools-dev autoconf git libssl-dev libtool xsltproc zlib1g-dev zip
-	
+
 On Ubuntu 14.04, you need to also:
 
 	sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -56,11 +58,12 @@ Contributors to this testing repository include:
 
 - Shravan Mishra (University of Waterloo)
 - Douglas Stebila (University of Waterloo)
+- Ben Davies (University of Waterloo)
 
 ### Support
 
-Financial support for the development of Open Quantum Safe has been provided by Amazon Web Services and the Tutte Institute for Mathematics and Computing.  
+Financial support for the development of Open Quantum Safe has been provided by Amazon Web Services and the Tutte Institute for Mathematics and Computing.
 
-We'd like to make a special acknowledgement to the companies who have dedicated programmer time to contribute source code to OQS, including Amazon Web Services, evolutionQ, and Microsoft Research.  
+We'd like to make a special acknowledgement to the companies who have dedicated programmer time to contribute source code to OQS, including Amazon Web Services, evolutionQ, and Microsoft Research.
 
 Research projects which developed specific components of OQS have been supported by various research grants, including funding from the Natural Sciences and Engineering Research Council of Canada (NSERC); see the source papers for funding acknowledgments.


### PR DESCRIPTION
Added basic travis CI config to test:
* Ubuntu Xenial & Trusty (with default GCC versions)
* Mac OS with clang

ccache has been enabled to try to speed up the build too.