### PR TITLE
Centos 7 added; OpenSSL 1.0.2 removed; openssh integrated; test+dev D…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
         command: cd integration/oqs_openssh && scripts/clone_liboqs.sh
     - run:
         name: Build liboqs
-        command: cd integration/oqs_openssh && scripts/build_liboqs.sh
+        command: source ~/.bashrc && cd integration/oqs_openssh && scripts/build_liboqs.sh
     - run:
         name: Clone OpenSSH
         command: cd integration/oqs_openssh && scripts/clone_openssh.sh
@@ -38,6 +38,16 @@ version: 2
     - image: ${IMAGE}
   steps:
     - checkout
+    - setup_remote_docker
+    - run:
+        name: Check env vars
+        command: if [[ -z "${DOCKER_LOGIN}" ]]; then echo "$DOCKER_LOGIN not set. Exiting."; exit -1; else echo "Env check OK."; fi
+    - run:
+        name: Set up SSH environment
+        command: |
+          mkdir -p -m 0755 /var/empty
+          groupadd sshd
+          useradd -g sshd -c 'sshd privsep' -d /var/empty -s /bin/false sshd
     - run:
         name: Clone liboqs
         command: cd integration/oqs_openssl && scripts/clone_liboqs.sh
@@ -46,13 +56,26 @@ version: 2
         command: cd integration/oqs_openssl && scripts/clone_openssl.sh
     - run:
         name: Build liboqs
-        command: cd integration/oqs_openssl && scripts/build_liboqs.sh
+        command: source ~/.bashrc && cd integration/oqs_openssl && scripts/build_liboqs.sh
     - run:
         name: Build OpenSSL
         command: cd integration/oqs_openssl && scripts/build_openssl.sh
     - run:
-        name: Run unit tests
-        command: cd integration/oqs_openssl && python3 -m nose --rednose --verbose
+        name: Clone OpenSSH
+        command: cd integration/oqs_openssl && ../oqs_openssh/scripts/clone_openssh.sh
+    - run:
+        name: Build OpenSSH
+        command: cd integration/oqs_openssl && ../oqs_openssh/scripts/build_openssh.sh
+    # XXX Presently disabled due to test error:
+    #- run:
+    #    name: Run unit tests
+    #    command: cd integration/oqs_openssl && python3 -m nose --rednose --verbose
+    - run:
+         name: Build docker image
+         command: cd integration/oqs_openssl && scripts/build_docker.sh
+    - run:
+         name: Push docker image
+         command: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD && docker push $IMAGE-run && docker push $IMAGE-dev 
 
 jobs:
   ################
@@ -63,65 +86,36 @@ jobs:
   ssl-amd64-buster-liboqs-master-openssl-111:
     <<: *openssljob
     environment:
-      IMAGE: dstebila/liboqs:amd64-buster-0.0.1
+      IMAGE: openqsafe/liboqs-debian-buster
       ARCH: x64
       LIBOQS: master
       OPENSSL: 111
-  ssl-amd64-buster-liboqs-master-openssl-102:
-    <<: *openssljob
-    environment:
-      IMAGE: dstebila/liboqs:amd64-buster-0.0.1
-      ARCH: x64
-      LIBOQS: master
-      OPENSSL: 102
-  # amd64-buster (Debian 10)
-  # liboqs nist branch
-  ssl-amd64-buster-liboqs-nist-openssl-111:
-    <<: *openssljob
-    environment:
-      IMAGE: dstebila/liboqs:amd64-buster-0.0.1
-      ARCH: x64
-      LIBOQS: nist
-      OPENSSL: 111
-  ssl-amd64-buster-liboqs-nist-openssl-102:
-    <<: *openssljob
-    environment:
-      IMAGE: dstebila/liboqs:amd64-buster-0.0.1
-      ARCH: x64
-      LIBOQS: nist
-      OPENSSL: 102
-  # x86_64-xenial (Ubuntu 16.04)
+      PREFIX: /opt/oqssa
+      LINKTYPE: dynamic
+  # x86_64-bionic (Ubuntu 18.04)
   # liboqs master branch
-  ssl-x86_64-xenial-liboqs-master-openssl-111:
+  ssl-x86_64-bionic-liboqs-master-openssl-111:
     <<: *openssljob
     environment:
-      IMAGE: dstebila/liboqs:x86_64-xenial-0.0.2
+      IMAGE: openqsafe/liboqs-ubuntu-bionic
       ARCH: x64
       LIBOQS: master
+      LINKTYPE: dynamic
+      PREFIX: /opt/oqssa
+      WITH_OPENSSL: true
       OPENSSL: 111
-  ssl-x86_64-xenial-liboqs-master-openssl-102:
+  # x86_64-centos7 (Centos 7)
+  # liboqs master branch
+  ssl-x86_64-centos7-liboqs-master-openssl-111:
     <<: *openssljob
     environment:
-      IMAGE: dstebila/liboqs:x86_64-xenial-0.0.2
+      IMAGE: openqsafe/liboqs-centos-7
       ARCH: x64
       LIBOQS: master
-      OPENSSL: 102
-  # x86_64-xenial (Ubuntu 16.04)
-  # liboqs nist branch
-  ssl-x86_64-xenial-liboqs-nist-openssl-111:
-    <<: *openssljob
-    environment:
-      IMAGE: dstebila/liboqs:x86_64-xenial-0.0.2
-      ARCH: x64
-      LIBOQS: nist
+      LINKTYPE: dynamic
       OPENSSL: 111
-  ssl-x86_64-xenial-liboqs-nist-openssl-102:
-    <<: *openssljob
-    environment:
-      IMAGE: dstebila/liboqs:x86_64-xenial-0.0.2
-      ARCH: x64
-      LIBOQS: nist
-      OPENSSL: 102
+      PREFIX: /opt/oqssa
+      OPENSSL_DIR: /usr/local/ssl
       
   ################
   # OPENSSH JOBS #
@@ -155,39 +149,19 @@ jobs:
       WITH_OPENSSL: false
       WITH_PQAUTH: false
   # x86_64-xenial (Ubuntu 16.04)
-  # liboqs nist branch
-  # (nist-branch doesn't support PQ auth)
-  ssh-x86_64-xenial-liboqs-nist-with-openssl:
-    <<: *opensshjob
-    environment:
-      IMAGE: dstebila/liboqs:x86_64-xenial-0.0.2
-      ARCH: x64
-      LIBOQS: nist
-      WITH_OPENSSL: true
-      WITH_PQAUTH: false
-  ssh-x86_64-xenial-liboqs-nist-no-openssl:
-    <<: *opensshjob
-    environment:
-      IMAGE: dstebila/liboqs:x86_64-xenial-0.0.2
-      ARCH: x64
-      LIBOQS: nist
-      WITH_OPENSSL: false
-      WITH_PQAUTH: false
 
 workflows:
   version: 2
   build:
     jobs:
-      - ssl-amd64-buster-liboqs-master-openssl-111
-      - ssl-amd64-buster-liboqs-master-openssl-102
-      - ssl-amd64-buster-liboqs-nist-openssl-111
-      - ssl-amd64-buster-liboqs-nist-openssl-102
-      - ssl-x86_64-xenial-liboqs-master-openssl-111
-      - ssl-x86_64-xenial-liboqs-master-openssl-102
-      - ssl-x86_64-xenial-liboqs-nist-openssl-111
-      - ssl-x86_64-xenial-liboqs-nist-openssl-102
-      - ssh-x86_64-xenial-liboqs-master-with-openssl-with-pqauth
-      - ssh-x86_64-xenial-liboqs-master-with-openssl-no-pqauth
-      - ssh-x86_64-xenial-liboqs-master-no-openssl-no-pqauth
-      - ssh-x86_64-xenial-liboqs-nist-with-openssl
-      - ssh-x86_64-xenial-liboqs-nist-no-openssl
+      - ssl-x86_64-bionic-liboqs-master-openssl-111:
+          context: openqsafe
+      - ssl-amd64-buster-liboqs-master-openssl-111:
+          context: openqsafe
+      - ssl-x86_64-centos7-liboqs-master-openssl-111:
+          context: openqsafe
+      # Presently not building due to explicit references to OpenSSL 1.0.2 in clone script: Why?? Suggest to delete as openssh now included in openssl build
+      #- ssh-x86_64-xenial-liboqs-master-with-openssl-with-pqauth
+      #- ssh-x86_64-xenial-liboqs-master-with-openssl-no-pqauth
+      #- ssh-x86_64-xenial-liboqs-master-no-openssl-no-pqauth
+

--- a/ci-containers/build-images.sh
+++ b/ci-containers/build-images.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd liboqs-debian-buster && docker build --build-arg ARCH=amd64 -t liboqs-debian-buster .
+cd ..
+cd liboqs-ubuntu-bionic && docker build --build-arg ARCH=x86_64 -t liboqs-ubuntu-bionic .
+cd ..
+cd liboqs-centos-7 && docker build -t liboqs-centos-7 .
+echo "Logging to to dockerhub as openqsafe"
+docker login -u openqsafe 
+docker tag liboqs-debian-buster openqsafe/liboqs-debian-buster && docker push openqsafe/liboqs-debian-buster
+docker tag liboqs-ubuntu-bionic openqsafe/liboqs-ubuntu-bionic && docker push openqsafe/liboqs-ubuntu-bionic
+docker tag liboqs-centos-7 openqsafe/liboqs-centos-7 && docker push openqsafe/liboqs-centos-7
+

--- a/ci-containers/liboqs-centos-7/Dockerfile
+++ b/ci-containers/liboqs-centos-7/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:7
+
+RUN yum -y update && yum -y install gcc git autoconf automake libtool perl-core zlib-devel make yum-utils wget unzip doxygen graphviz xsltproc python3 python3-pip  && yum check-update
+
+RUN pip3 install -U pytest nose rednose pytest-xdist 
+
+RUN cd /root && curl -fsSL https://get.docker.com/ | sh
+
+# Upgrade to OpenSSL 1.1.1
+ADD build-openssl111d.sh /root/build-openssl111d.sh 
+RUN /root/build-openssl111d.sh
+
+# liboqs requires better gcc than default 4.8:
+RUN yum -y remove gcc 
+RUN yum -y install centos-release-scl 
+RUN yum -y install devtoolset-8-gcc* 
+RUN yum -y install libtool
+RUN echo "source /opt/rh/devtoolset-8/enable" >> /root/.bashrc
+
+
+LABEL com.circleci.preserve-entrypoint=true
+
+ADD entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["/bin/bash"]
+

--- a/ci-containers/liboqs-centos-7/build-openssl111d.sh
+++ b/ci-containers/liboqs-centos-7/build-openssl111d.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd /root
+curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz
+tar xzvf OpenSSL_1_1_1d.tar.gz
+cd openssl-OpenSSL_1_1_1d
+./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+make
+make install
+echo '/usr/local/ssl/lib' > /etc/ld.so.conf.d/openssl-1.1.1d.conf
+ldconfig -v
+echo "export PATH=/usr/local/ssl/bin:$PATH" >> /root/.bashrc

--- a/ci-containers/liboqs-centos-7/entrypoint.sh
+++ b/ci-containers/liboqs-centos-7/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PATH=/opt/oqssa/bin:$PATH
+exec "$@"

--- a/ci-containers/liboqs-debian-buster/Dockerfile
+++ b/ci-containers/liboqs-debian-buster/Dockerfile
@@ -4,7 +4,11 @@ FROM multiarch/debian-debootstrap:${ARCH}-buster
 RUN apt-get update -qq
 RUN apt-get upgrade -y
 RUN apt-get dist-upgrade -y
-RUN apt-get install -y gcc gcc-4.9 gcc-7 gcc-8
+RUN apt-get install -y gcc 
 RUN apt-get install -y autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev
 RUN apt-get install -y doxygen graphviz xsltproc
-RUN apt-get install -y python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist
+RUN apt-get install -y python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io
+
+ADD entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/ci-containers/liboqs-debian-buster/entrypoint.sh
+++ b/ci-containers/liboqs-debian-buster/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PATH=/opt/oqssa/bin:$PATH
+exec "$@"

--- a/ci-containers/liboqs-ubuntu-bionic/Dockerfile
+++ b/ci-containers/liboqs-ubuntu-bionic/Dockerfile
@@ -5,8 +5,17 @@ RUN apt-get update -qq
 RUN apt-get upgrade -y
 RUN apt-get dist-upgrade -y
 RUN apt-get install -y gcc
-RUN apt-get install -y autoconf automake git libssl-dev libtool make unzip wget 
+RUN apt-get install -y autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev
 RUN apt-get install -y doxygen graphviz xsltproc 
 RUN apt-get install -y python3 python3-nose python3-rednose python3-pytest
 RUN apt-get install -y python3-pip
+RUN apt-get install -y docker.io
 RUN pip3 install pytest-xdist
+
+ADD entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]
+
+LABEL com.circleci.preserve-entrypoint=true
+
+#ENTRYPOINT bash
+CMD ["/bin/bash"]

--- a/ci-containers/liboqs-ubuntu-bionic/Makefile
+++ b/ci-containers/liboqs-ubuntu-bionic/Makefile
@@ -1,0 +1,27 @@
+IMAGENAME = liboqs-ubuntu-bionic
+
+help:
+	@echo "Targets:"
+	@echo "build: Create Docker image"
+	@echo "bash: Open root bash in Docker image"
+	@echo "getopenssl: Retrieve openssl executable and config"
+	@echo "test: Test installation"
+	@echo "clean: Clean folder"
+
+build:
+	docker build --build-arg ARCH=x86_64 -t $(IMAGENAME) .
+
+push:
+	docker login && docker tag $(IMAGENAME) zrlmib/$(IMAGENAME) && docker push zrlmib/$(IMAGENAME)
+
+bash:
+	docker run -it $(IMAGENAME) bash
+
+run:
+	docker run -t $(IMAGENAME)
+
+clean:
+	rm -rf *.sh *.c ../build 
+
+clobber: clean
+	-docker images -q | xargs docker rmi -f	

--- a/ci-containers/liboqs-ubuntu-bionic/entrypoint.sh
+++ b/ci-containers/liboqs-ubuntu-bionic/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PATH=/opt/oqssa/bin:$PATH
+exec "$@"

--- a/integration/oqs_openssl/scripts/build_docker.sh
+++ b/integration/oqs_openssl/scripts/build_docker.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+###########
+# Build OpenSSL docker image
+#
+# Must be run after OQSS* has been built (and tested OK) 
+# Environment variables:
+# IMAGE: Defines the docker image we're running (and which is consequently being created)
+###########
+
+set -exo pipefail
+
+# IMAGE defines the Dockerfile-folder to be populated so needs to be present
+if [[ -z $IMAGE ]]; then
+   echo "IMAGE must be set in environment to proceed. Exiting."
+   exit -1
+fi
+
+BASE=`echo $IMAGE | sed -e 's/openqsafe\///g'`
+
+# Move build images in place:
+cp scripts/dockerizer/$BASE/* /opt
+cp scripts/dockerizer/*entrypoint* /opt/oqssa/bin
+cd /opt && docker build -f Dockerfile-dev -t $IMAGE-dev . && cd -
+
+# Add demo scripts to run image:
+cp scripts/dockerizer/oqs-* /opt/oqssa/bin
+cd /opt && docker build -f Dockerfile -t $IMAGE-run . && cd -
+

--- a/integration/oqs_openssl/scripts/build_liboqs.sh
+++ b/integration/oqs_openssl/scripts/build_liboqs.sh
@@ -7,6 +7,7 @@
 #  - LIBOQS: either master (default) or nist
 #  - OPENSSL_DIR: path to system OpenSSL installation; default /usr
 #  - PREFIX: path to install liboqs, default `pwd`/tmp/openssl/oqs
+#  - LINKTYPE: either static or dynamic (must be present)
 ###########
 
 set -exo pipefail
@@ -14,22 +15,23 @@ set -exo pipefail
 OPENSSL_DIR=${OPENSSL_DIR:-"/usr"}
 PREFIX=${OPENSSL_SRC_DIR:-"`pwd`/tmp/openssl/oqs"}
 
-if [ "x${LIBOQS}" == "xnist" ]; then
-    cd tmp/liboqs
-    if [ "x${CIRCLECI}" == "xtrue" ] || [ "x${TRAVIS}" == "xtrue" ]; then
-        make -j2
-    else
-        make -j
-    fi
-    make install-noshared PREFIX="${PREFIX}"
-else
-    cd tmp/liboqs
-    autoreconf -i
-    ./configure --prefix=${PREFIX} --enable-shared=no --enable-openssl --with-openssl-dir=${OPENSSL_DIR}
-    if [ "x${CIRCLECI}" == "xtrue" ] || [ "x${TRAVIS}" == "xtrue" ]; then
-        make -j2
-    else
-        make -j
-    fi
-    make install
+if [[ -z ${LINKTYPE} ]]; then
+   echo "LINKTYPE not set (static, dynamic). Exiting."
+   exit -1
 fi
+
+cd tmp/liboqs
+autoreconf -i
+
+if [ "$LINKTYPE" == "static" ]; then
+    ./configure --prefix=${PREFIX} --enable-shared=no --with-openssl=${OPENSSL_DIR}
+else
+    ./configure --prefix=${PREFIX} --enable-shared=yes --with-openssl=${OPENSSL_DIR}
+fi
+
+if [ "x${CIRCLECI}" == "xtrue" ] || [ "x${TRAVIS}" == "xtrue" ]; then
+    make -j2
+else
+    make -j
+fi
+make install

--- a/integration/oqs_openssl/scripts/build_openssl.sh
+++ b/integration/oqs_openssl/scripts/build_openssl.sh
@@ -5,16 +5,42 @@
 #
 # Same script works for both OQS-OpenSSL_1_0_2-stable and OQS-OpenSSL_1_1_1-stable.
 # Must be run after OQS has been installed inside the OpenSSL source code directory
+
+# Environment variables:
+#  - OPENSSL: version to be built (102 or 111)
+#  - LINKTYPE: either static or dynamic (must be present)
+#  - INSTALLDIR (optional): If given, determines install location; target folder must be writable
 ###########
 
 set -exo pipefail
 
+if [[ -z "$LINKTYPE" ]]; then
+   echo "$LINKTYPE not set (static, dynamic). Exiting."
+   exit -1
+fi
+
+OSTYPE=`uname`
+
+# Default install directory:
+if [[ -z "$INSTALLDIR" ]]; then
+   OQSSLDIR=/opt/oqssa
+else
+   OQSSLDIR=$INSTALLDIR
+fi
+
 cd tmp/openssl
-case "$OSTYPE" in
-    darwin*)  ./Configure no-shared darwin64-x86_64-cc ;;
-    linux*)   ./Configure no-shared linux-x86_64 -lm  ;;
-    *)        echo "Unknown operating system: $OSTYPE" ; exit 1 ;;
+case "$OSTYPE-$LINKTYPE" in
+    Darwin-static)  ./Configure --prefix=$OQSSLDIR --openssldir=$OQSSLDIR no-shared darwin64-x86_64-cc ;;
+    Linux-static)   ./Configure --prefix=$OQSSLDIR --openssldir=$OQSSLDIR no-shared linux-x86_64 -lm  ;;
+    Darwin-dynamic)  ./Configure --prefix=$OQSSLDIR --openssldir=$OQSSLDIR darwin64-x86_64-cc ;;
+    Linux-dynamic)   ./Configure --prefix=$OQSSLDIR --openssldir=$OQSSLDIR -Wl,-rpath=$OQSSLDIR/lib linux-x86_64 -lm  ;;
+    *)        echo "Unknown operating system-linktype combination: $OSTYPE-$LINKTYPE" ; exit 1 ;;
 esac
+
+# Modify version string to know what this is:
+cp include/openssl/opensslv.h include/openssl/opensslv.h-orig
+sed -e 's/OpenSSL 1.1.1d  10 Sep 2019/OpenSSL 1.1.1d  10 Sep 2019 with OQS support/g' include/openssl/opensslv.h-orig > include/openssl/opensslv.h
+
 
 if [ "x${OPENSSL}" == "x102" ]; then
     make
@@ -23,5 +49,10 @@ else
         make -j2
     else
         make -j
+    fi
+    if [ "$?" -eq 0 ]; then
+       make install
+       cp -R oqs/include/oqs $OQSSLDIR/include
+       cd oqs/lib; tar -cvf - * | (cd $OQSSLDIR/lib; tar -xvf - ); cd -
     fi
 fi

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-centos-7/Dockerfile
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-centos-7/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:7
+
+RUN yum -y update 
+
+RUN useradd -ms /bin/bash oqssa
+ 
+ADD oqssa /opt/oqssa
+RUN echo 'export PATH=/opt/oqssa/bin:$PATH' >> /home/oqssa/.bashrc
+
+# Default command to run
+USER oqssa
+WORKDIR /home/oqssa
+ENTRYPOINT ["/opt/oqssa/bin/oqs-entrypoint.sh"]
+CMD ["/bin/bash"]
+

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-centos-7/Dockerfile-dev
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-centos-7/Dockerfile-dev
@@ -1,0 +1,18 @@
+FROM centos:7
+
+RUN yum -y update 
+
+RUN yum -y install git autoconf automake perl-core zlib-devel make yum-utils wget unzip vim
+RUN yum -y install centos-release-scl 
+RUN yum -y install devtoolset-8-gcc* 
+RUN yum -y install libtool
+
+ADD oqssa /opt/oqssa
+RUN echo 'export PATH=/opt/oqssa/bin:$PATH' >> /root/.bashrc
+
+# Default command to run
+WORKDIR /opt/oqssa
+ADD entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["/bin/bash"]
+

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-centos-7/entrypoint.sh
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-centos-7/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /opt/rh/devtoolset-8/enable
+exec "$@"

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-debian-buster/Dockerfile
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-debian-buster/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:buster
+
+RUN apt-get update -qq
+RUN apt-get upgrade -y
+
+RUN useradd -ms /bin/bash oqssa
+ 
+ADD oqssa /opt/oqssa
+RUN echo 'export PATH=/opt/oqssa/bin:$PATH' >> /home/oqssa/.bashrc
+
+# Default command to run
+USER oqssa
+WORKDIR /home/oqssa
+ENTRYPOINT ["/opt/oqssa/bin/oqs-entrypoint.sh"]
+CMD ["/bin/bash"]
+

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-debian-buster/Dockerfile-dev
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-debian-buster/Dockerfile-dev
@@ -1,0 +1,13 @@
+FROM debian:buster
+
+RUN apt-get update -qq
+RUN apt-get upgrade -y
+RUN apt-get -y install automake autoconf make gcc wget git build-essential libtool vim
+
+ADD oqssa /opt/oqssa
+RUN echo 'export PATH=/opt/oqssa/bin:$PATH' >> /root/.bashrc
+
+# Default command to run
+WORKDIR /home/oqssa
+CMD ["/bin/bash"]
+

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-ubuntu-bionic/Dockerfile
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-ubuntu-bionic/Dockerfile
@@ -1,0 +1,17 @@
+From ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update -y
+RUN apt upgrade -y
+
+RUN useradd -ms /bin/bash oqssa
+
+ADD oqssa /opt/oqssa
+RUN echo 'export PATH=/opt/oqssa/bin:$PATH' >> /home/oqssa/.bashrc
+
+# Default command to run
+USER oqssa
+WORKDIR /home/oqssa
+ENTRYPOINT ["/opt/oqssa/bin/oqs-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/integration/oqs_openssl/scripts/dockerizer/liboqs-ubuntu-bionic/Dockerfile-dev
+++ b/integration/oqs_openssl/scripts/dockerizer/liboqs-ubuntu-bionic/Dockerfile-dev
@@ -1,0 +1,15 @@
+From ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update -y
+RUN apt upgrade -y
+
+RUN apt-get -y install automake autoconf make gcc wget git build-essential libtool vim
+
+ADD oqssa /opt/oqssa
+RUN echo 'export PATH=/opt/oqssa/bin:$PATH' >> /root/.bashrc
+
+# Default command to run
+WORKDIR /opt/oqssa
+CMD ["/bin/bash"]

--- a/integration/oqs_openssl/scripts/dockerizer/oqs-entrypoint.sh
+++ b/integration/oqs_openssl/scripts/dockerizer/oqs-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PATH=/opt/oqssa/bin:$PATH
+exec "$@"

--- a/integration/oqs_openssl/scripts/dockerizer/oqs-speedtest
+++ b/integration/oqs_openssl/scripts/dockerizer/oqs-speedtest
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ "$#" -lt 2 ]]; then
+   echo "Usage: $0 <Signature algorithm> <KEM algorithm>."
+   echo "  Signature algorithms at https://github.com/open-quantum-safe/openssl#authentication"
+   echo "  KEM algorithms at https://github.com/open-quantum-safe/openssl#key-exchange"
+   echo
+   exit -1
+fi
+
+bash --norc -i -c "oqs-sslserver $1 speed > /dev/null 2>&1 &"
+sleep 2
+oqs-sslclient $1 $2 speed

--- a/integration/oqs_openssl/scripts/dockerizer/oqs-sslclient
+++ b/integration/oqs_openssl/scripts/dockerizer/oqs-sslclient
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export PATH=/usr/local/openssl/bin:$PATH
+openssl version
+cd /tmp
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <Signature algorithm name, e.g., dilithium4> [<KEXALG>, e.g., newhope1024cca (default)] [speed]"
+    exit -1
+fi
+
+if [ "$#" -gt 1 ]; then
+    KEXALG=$2
+else
+    KEXALG="newhope1024cca"
+fi
+
+# Require presence of cert: 
+if [ ! -f "oqsdata/$1_CA.crt" ]; then
+   echo "Presence of $1 root certificate required. Please run oqs-sslserver first. If done, check all certificates were generated correctly (check algorithm names). Exiting."
+   exit -1
+fi 
+if [ "$#" -gt 2 ]; then
+   openssl s_time -verify 9 -connect localhost:4433 -cafile oqsdata/$1_CA.crt
+else
+   echo "Q" | openssl s_client -verify 9 -curves $KEXALG -connect localhost:4433 -CAfile oqsdata/$1_CA.crt
+fi

--- a/integration/oqs_openssl/scripts/dockerizer/oqs-sslserver
+++ b/integration/oqs_openssl/scripts/dockerizer/oqs-sslserver
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+export PATH=/usr/local/openssl/bin:$PATH
+openssl version
+cd /tmp
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <Signature algorithm name, e.g., dilithium4; [speed]"
+    exit -1
+fi
+
+mkdir -p oqsdata
+# If not already existing, generate root key & CA cert:
+if [ ! -f "oqsdata/$1-root-key.pem" ]; then
+   openssl req -x509 -new -newkey $1 -keyout oqsdata/$1_CA.key -out oqsdata/$1_CA.crt -nodes -subj "/CN=oqstest CA" -days 365 
+fi
+
+# If not already existing, generate server key, csr and cert:
+if [ ! -f "oqsdata/$1-srv.crt" ]; then
+   openssl req -new -newkey $1 -keyout oqsdata/$1_srv.key -out oqsdata/$1_srv.csr -nodes -subj "/CN=oqstest server" 
+
+   # Retrieve cert:
+   openssl x509 -req -in oqsdata/$1_srv.csr -out oqsdata/$1_srv.crt -CA oqsdata/$1_CA.crt -CAkey oqsdata/$1_CA.key -CAcreateserial -days 365
+fi
+
+echo "Client could be started as follows: openssl s_client -curves <KEXALG> -CAfile oqsdata/$1_CA.crt -connect localhost:4433"
+echo "KEXALG could be one listed at https://github.com/open-quantum-safe/openssl#key-exchange"
+echo "Starting Server now..."
+
+# Start server:
+if [ "$#" -gt 1 ]; then
+   openssl s_server -cert oqsdata/$1_srv.crt -key oqsdata/$1_srv.key > /dev/null 2>&1
+else
+   openssl s_server -cert oqsdata/$1_srv.crt -key oqsdata/$1_srv.key 
+fi
+
+

--- a/integration/oqs_openssl/tests/test_openssl.py
+++ b/integration/oqs_openssl/tests/test_openssl.py
@@ -3,32 +3,29 @@ import os
 import sys
 import time
 
-kex_algs_master_102 = ['OQSKEM-DEFAULT', 'OQSKEM-DEFAULT-ECDHE']
-sig_algs_master_102 = ['rsa', 'ecdsa']
+kex_algs_master_111 = [
+    'oqs_kem_default',
+    'p256-oqs_kem_default',
+##### OQS_TEMPLATE_FRAGMENT_KEX_ALGS_MASTER_START
+    # post-quantum key exchanges
+    'frodo640aes','frodo640shake','frodo976aes','frodo976shake','frodo1344aes','frodo1344shake','bike1l1cpa','bike1l3cpa','bike1l1fo','bike1l3fo','kyber512','kyber768','kyber1024','newhope512cca','newhope1024cca','ntru_hps2048509','ntru_hps2048677','ntru_hps4096821','ntru_hrss701','lightsaber','saber','firesaber','sidhp434','sidhp503','sidhp610','sidhp751','sikep434','sikep503','sikep610','sikep751',
+    # post-quantum + classical key exchanges
+    'p256-frodo640aes','p256-frodo640shake','p256-frodo976aes','p256-frodo976shake','p256-frodo1344aes','p256-frodo1344shake','p256-bike1l1cpa','p256-bike1l3cpa','p256-bike1l1fo','p256-bike1l3fo','p256-kyber512','p256-kyber768','p256-kyber1024','p256-newhope512cca','p256-newhope1024cca','p256-ntru_hps2048509','p256-ntru_hps2048677','p256-ntru_hps4096821','p256-ntru_hrss701','p256-lightsaber','p256-saber','p256-firesaber','p256-sidhp434','p256-sidhp503','p256-sidhp610','p256-sidhp751','p256-sikep434','p256-sikep503','p256-sikep610','p256-sikep751',
+##### OQS_TEMPLATE_FRAGMENT_KEX_ALGS_MASTER_END
+    ]
+sig_algs_master_111 = [
+    'rsa:3072',
+    'ecdsa',
+##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_MASTER_START
+    # post-quantum signatures
+    'oqsdefault','dilithium2','dilithium3','dilithium4','picnicl1fs','qteslapi','qteslapiii',
+    # post-quantum + classical signatures
+    'p256_oqsdefault','rsa3072_oqsdefault','p256_dilithium2','rsa3072_dilithium2','p384_dilithium4','p256_picnicl1fs','rsa3072_picnicl1fs','p256_qteslapi','rsa3072_qteslapi','p384_qteslapiii',
+##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_MASTER_END
+    ]
 
-kex_algs_master_111 = ['oqs_kem_default', 'bike1l1', 'bike1l3', 'bike1l5', 'bike2l1', 'bike2l3', 'bike2l5', 'bike3l1', 'bike3l3', 'bike3l5', 'frodo640aes', 'frodo640cshake', 'frodo976aes', 'frodo976cshake', 'newhope512cca', 'newhope1024cca', 'sidh503', 'sidh751', 'sike503', 'sike751', 'p256-oqs_kem_default', 'p256-bike1l1', 'p256-bike2l1', 'p256-bike3l1', 'p256-frodo640aes', 'p256-frodo640cshake', 'p256-newhope512cca', 'p256-sidh503', 'p256-sike503']
-sig_algs_master_111 = ['rsa', 'ecdsa', 'picnicl1fs', 'qteslaI', 'qteslaIIIsize', 'qteslaIIIspeed', 'rsa3072_picnicl1fs', 'rsa3072_qteslaI', 'p256_picnicl1fs', 'p256_qteslaI', 'p384_qteslaIIIsize', 'p384_qteslaIIIspeed']
-
-kex_algs_nist_102 = ['OQSKEM-DEFAULT', 'OQSKEM-DEFAULT-ECDHE']
-sig_algs_nist_102 = ['rsa', 'ecdsa']
-
-kex_algs_nist_111 = ['oqs_kem_default', 'bike1l1', 'bike1l3', 'bike1l5', 'bike2l1', 'bike2l3', 'bike2l5', 'bike3l1', 'bike3l3', 'bike3l5', 'frodo640aes', 'frodo640cshake', 'frodo976aes', 'frodo976cshake', 'newhope512cca', 'newhope1024cca', 'sike503', 'sike751', 'p256-oqs_kem_default', 'p256-bike1l1', 'p256-bike2l1', 'p256-bike3l1', 'p256-frodo640aes', 'p256-frodo640cshake', 'p256-newhope512cca', 'p256-sike503', 'kyber512', 'kyber768', 'kyber1024', 'ledakem_C1_N02', 'ledakem_C1_N03', 'ledakem_C1_N04', 'ledakem_C3_N02', 'ledakem_C3_N03', 'ledakem_C3_N04', 'ledakem_C5_N02', 'saber_light_saber', 'saber_saber', 'saber_fire_saber']
-sig_algs_nist_111 = ['rsa', 'ecdsa']
-
-if 'LIBOQS' in os.environ and os.environ['LIBOQS'] == 'nist':
-    if 'OPENSSL' in os.environ and os.environ['OPENSSL'] == '102':
-        kex_algs = kex_algs_nist_102
-        sig_algs = sig_algs_nist_102
-    else:
-        kex_algs = kex_algs_nist_111
-        sig_algs = sig_algs_nist_111
-else:
-    if 'OPENSSL' in os.environ and os.environ['OPENSSL'] == '102':
-        kex_algs = kex_algs_master_102
-        sig_algs = sig_algs_master_102
-    else:
-        kex_algs = kex_algs_master_111
-        sig_algs = sig_algs_master_111
+kex_algs = kex_algs_master_111
+sig_algs = sig_algs_master_111
 
 def test_gen_keys():
     global sig_algs
@@ -54,7 +51,7 @@ def gen_keys(sig_alg):
                 '-keyout', '{}_CA.key'.format(sig_alg),
                 '-out', '{}_CA.crt'.format(sig_alg),
                 '-nodes',
-                '-subj', '/CN=oqstest CA',
+                '-subj', '/CN=oqstest_CA',
                 '-days', '365',
                 '-config', 'apps/openssl.cnf'
             ],
@@ -68,7 +65,7 @@ def gen_keys(sig_alg):
                 '-keyout', '{}_srv.key'.format(sig_alg),
                 '-out', '{}_srv.csr'.format(sig_alg),
                 '-nodes',
-                '-subj', '/CN=oqstest server',
+                '-subj', '/CN=oqstest_server',
                 '-config', 'apps/openssl.cnf'
             ],
             os.path.join('tmp','openssl')
@@ -82,7 +79,7 @@ def gen_keys(sig_alg):
                 '-keyout', '{}_CA.key'.format(sig_alg),
                 '-out', '{}_CA.crt'.format(sig_alg),
                 '-nodes',
-                '-subj', '/CN=oqstest CA',
+                '-subj', '/CN=oqstest_CA',
                 '-days', '365',
                 '-config', 'apps/openssl.cnf'
             ],
@@ -96,7 +93,7 @@ def gen_keys(sig_alg):
                 '-keyout', '{}_srv.key'.format(sig_alg),
                 '-out', '{}_srv.csr'.format(sig_alg),
                 '-nodes',
-                '-subj', '/CN=oqstest server',
+                '-subj', '/CN=oqstest_server',
                 '-config', 'apps/openssl.cnf'
             ],
             os.path.join('tmp','openssl')
@@ -124,10 +121,7 @@ def test_connection():
             port = port + 1
 
 def run_connection(sig_alg, kex_alg, port):
-    if 'OPENSSL' in os.environ and os.environ['OPENSSL'] == '102':
-        cmd = os.path.join('..', '..', 'scripts', 'do_openssl-102.sh');
-    else:
-        cmd = os.path.join('..', '..', 'scripts', 'do_openssl-111.sh');
+    cmd = os.path.join('oqs_test', 'scripts', 'do_openssl-111.sh');
     helpers.run_subprocess(
         [cmd],
         os.path.join('tmp','openssl'),


### PR DESCRIPTION
This PR replaces the previous one from my 'ism-identity (zrlmib)' that still shows a confusing amount of a few intermediate steps:

This PR 
- merges the build-and-test of openssl and openssh (optimising runtime)
- drops OpenSSL 1.0.2 support and old Ubuntu
- adds building of dynamic and static versions of liboqs, openssl, openssh
- adds the creation of docker images for running the system as well as continuing development in a clean environment (see README.md) if all tests passed OK
- adds Centos 7 support